### PR TITLE
chore: pr-review-apply 스킬 추가

### DIFF
--- a/.claude/skills/pr-review-apply/SKILL.md
+++ b/.claude/skills/pr-review-apply/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: pr-review-apply
+description: 본인 PR이 받은 리뷰 코멘트를 분석해 반영·반박·보류 중 하나로 처리하고 rebase로 기존 커밋을 직접 수정. Use when the user says "pr-review-apply", "리뷰 반영", "리뷰 반영해", "review apply", "PR 리뷰 반영".
+---
+
+본인 PR이 받은 리뷰 코멘트를 코드 재분석 후 처리하고, rebase로 관련 커밋을 직접 수정한다.
+
+## 핵심 원칙
+
+- **본인 PR만 대상** — author가 현재 사용자가 아니면 즉시 중단
+- **각 코멘트마다 자율 판단** — 반영 / 반박 / 보류 중 하나
+- **반박·보류 시 근거 자료 필수** — 코드 인용, 라인 번호, 패턴 참조, 문서 링크
+- **rebase로 커밋 직접 수정** — 새 "fix" 커밋 추가 금지. fixup + autosquash로 원래 커밋에 합친다
+- **반응 이모지로 동의도 표현** — `pr-review` 스킬의 이모지 정책 준용
+
+## Steps
+
+### 1. 대상 PR 확인 및 권한 검증
+
+```bash
+# 사용자가 PR 번호를 지정하면 그 PR만, 아니면 현재 브랜치의 PR
+PR=${1:-$(gh pr view --json number --jq .number)}
+ME=$(gh api user --jq '.login')
+AUTHOR=$(gh pr view $PR --json author --jq '.author.login')
+```
+
+**중단 조건:**
+
+- `AUTHOR != ME` → "본인 PR만 처리합니다" 출력 후 종료
+- PR 상태가 `MERGED`/`CLOSED` → "이미 닫힌 PR입니다" 출력 후 종료
+- 현재 브랜치가 PR HEAD 브랜치와 다름 → 자동 checkout 시도, 실패 시 종료
+
+### 2. 미해결 리뷰 코멘트 수집
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first:50) {
+              nodes {
+                databaseId
+                author { login }
+                body
+                path
+                line
+                originalLine
+                diffHunk
+                commit { oid }
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner={owner} -F repo={repo} -F number=$PR
+```
+
+**처리 대상 필터:**
+
+- `isResolved == false` (이미 해결된 건 스킵)
+- 첫 코멘트 작성자 ≠ 본인 (내가 자기 PR에 단 코멘트는 제외)
+- 마지막 코멘트 작성자가 본인이 아님 (이미 답한 건 스킵 — 새 답글이 달리면 재처리)
+
+**이미 outdated인 스레드 처리:**
+
+- `isOutdated == true` + 본인이 답하지 않은 경우 → 코드를 다시 보고 실제 반영됐는지 확인
+    - 반영됨 → "이미 후속 커밋에서 반영됨 (SHA 인용)" 답글 + resolve
+    - 미반영 → 일반 처리 흐름으로 진행
+
+### 3. 각 코멘트 분류 (반영 / 반박 / 보류)
+
+각 미해결 코멘트마다 코드 재분석 후 분류한다.
+
+| 분류            | 판단 기준                                                | 처리                                     |
+| --------------- | -------------------------------------------------------- | ---------------------------------------- |
+| **반영(APPLY)** | 지적이 타당하고 변경 비용이 합리적                       | 코드 수정 + 답글 + 이모지                |
+| **반박(REBUT)** | 지적 근거가 잘못됨, 의도된 동작, 트레이드오프상 부적절   | 답글에 **근거 자료 필수** + 이모지       |
+| **보류(HOLD)**  | 추가 정보·결정 필요 (예: 디자인 결정, 다른 팀 합의 대기) | 답글에 **무엇이 필요한지 명시** + 이모지 |
+
+**반박·보류는 근거 자료 의무화**
+
+근거에 다음 중 **2개 이상** 포함:
+
+- 코드 인용 (`path:line` + 코드 블록)
+- 기존 패턴 참조 (다른 파일에서 동일 패턴 사용 사례)
+- 프로젝트 룰 인용 (`.claude/rules/*.mdc` 항목)
+- 외부 문서 링크 (공식 docs, RFC, 표준)
+- 트레이드오프 분석 (대안 X, Y 비교)
+
+근거가 부족하면 강제로 분류를 **반영(APPLY)** 으로 전환한다.
+
+### 4. 반영(APPLY) 처리 — rebase로 기존 커밋 직접 수정
+
+**새 "fix: review feedback" 커밋을 추가하지 않는다.** 지적된 라인의 원인 커밋을 찾아 그 커밋을 직접 수정한다.
+
+#### 4-1. 원인 커밋 찾기
+
+```bash
+# 코멘트가 가리키는 파일+라인의 원인 커밋
+TARGET_COMMIT=$(git blame -L <line>,<line> <file> | awk '{print $1}')
+# blame 결과가 PR 범위 밖(main 등) 커밋이면 → 새 커밋 필요 (예외)
+```
+
+PR 범위 안 커밋이면 그 커밋에 fixup 한다. 범위 밖이면 §4-3로.
+
+#### 4-2. 코드 수정 + fixup 커밋
+
+```bash
+# 1) 코드 수정 (Edit 도구로)
+# 2) fixup 커밋 생성
+git add <file>
+git commit --fixup=$TARGET_COMMIT
+
+# 3) PR 베이스 브랜치로부터 autosquash rebase
+BASE=$(gh pr view $PR --json baseRefName --jq .baseRefName)
+GIT_SEQUENCE_EDITOR=: git rebase --autosquash --interactive origin/$BASE
+```
+
+**주의: `GIT_SEQUENCE_EDITOR=:`** — 에디터 안 띄우고 자동 진행. autosquash가 fixup을 원래 커밋에 합친다.
+
+rebase 충돌 발생 시 **자동 해결 시도하지 않는다.** 사용자에게 알리고 중단.
+
+#### 4-3. 원인 커밋이 PR 범위 밖인 경우
+
+main 등 베이스 브랜치 커밋을 수정할 수 없으므로 새 커밋을 만든다 (예외 케이스).
+
+```bash
+git add <file>
+git commit -m "fix: <리뷰 반영 내용 요약> (review #<comment_id>)"
+```
+
+이 케이스는 결과 보고에 `EXCEPTION (base commit)` 으로 표시.
+
+#### 4-4. force push
+
+rebase 후 history가 바뀌므로 force-push 필요. **반드시 `--force-with-lease` 사용** (다른 사람이 푸시한 게 있으면 안전하게 거부됨).
+
+```bash
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# main 보호
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+  echo "ERROR: main/master 브랜치에는 force-push 금지"
+  exit 1
+fi
+
+git push --force-with-lease origin $CURRENT_BRANCH
+```
+
+**금지:**
+
+- ❌ `git push --force` (단순 force) — 항상 `--force-with-lease`
+- ❌ main/master 브랜치 force-push
+- ❌ commit hooks 우회 (`--no-verify`)
+
+#### 4-5. 답글 + 이모지
+
+```bash
+# 답글 (스레드의 마지막 코멘트에 reply)
+gh api repos/{owner}/{repo}/pulls/$PR/comments/<comment_id>/replies -X POST \
+  -f body="반영했습니다. <간단한 설명> ($(git rev-parse --short HEAD))"
+
+# 이모지 반응 — 반영 동의 표시
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -X POST -f content="+1"
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -X POST -f content="rocket"
+```
+
+#### 4-6. resolve 금지
+
+**작성자는 어떤 경우에도 resolve하지 않는다.** resolve는 리뷰어만 수행한다.
+
+- 단순 기계적 변경(오타·포맷·린트)이라도 resolve 금지 — 리뷰어가 반영 여부를 직접 확인하게 함
+- 작성자는 답글 + 커밋 SHA 인용까지만 담당
+
+### 5. 반박(REBUT) 처리
+
+코드 수정 없음. 답글에 근거 자료 포함.
+
+```bash
+gh api repos/{owner}/{repo}/pulls/$PR/comments/<comment_id>/replies -X POST -f body="<답글 본문>"
+```
+
+**답글 형식:**
+
+```
+<반박 입장 — 한 문장>
+
+**근거**
+1. <근거 1: 코드 인용 path:line 또는 패턴 참조>
+2. <근거 2: 룰 인용 또는 문서 링크>
+
+<선택: 트레이드오프 / 대안 / 추후 논의 제안>
+```
+
+**이모지 — 정중한 부동의:**
+
+```bash
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -X POST -f content="eyes"
+```
+
+resolve는 **하지 않는다** — 리뷰어가 답글 확인 후 동의/재반박 결정.
+
+### 6. 보류(HOLD) 처리
+
+코드 수정 없음. 답글에 필요한 정보 명시.
+
+```
+<무엇을 보류하는지 — 한 문장>
+
+**필요한 정보**
+- <항목 1>
+- <항목 2>
+
+<선택: 임시 조치 / 다음 액션 / 책임자 멘션>
+```
+
+**이모지 — 검토 중:**
+
+```bash
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -X POST -f content="thinking_face"
+# (thinking_face가 지원 안 되면 eyes 사용)
+```
+
+resolve는 **하지 않는다.**
+
+### 7. 이모지 반응 가이드 (동의도)
+
+`pr-review` 스킬의 §8 이모지 정책을 작성자 입장에서 미러링한다.
+
+| 분류                          | 동의도 | 사용 가능 이모지        |
+| ----------------------------- | ------ | ----------------------- |
+| 반영(APPLY) — 전적 동의       | 높음   | `+1`, `rocket`, `heart` |
+| 반영(APPLY) — 일부 변형 반영  | 중간   | `+1`, `eyes`            |
+| 반박(REBUT)                   | 낮음   | `eyes` (정중한 부동의)  |
+| 보류(HOLD)                    | 미정   | `eyes`                  |
+| P5 칭찬 받은 경우 (반영 불요) | 감사   | `heart`, `+1`           |
+
+**자율 판단**: 분위기와 PR 톤에 맞게 자연스럽게 선택. 과한 이모지 남발 금지 (코멘트당 최대 2개).
+
+**금지:** `confused`, `-1` 같은 부정적 이모지는 사용하지 않는다 (반박은 답글 본문으로).
+
+### 8. 리뷰어 재요청
+
+반영(APPLY)이 1건 이상 있으면 원 리뷰어를 재요청해서 후속 리뷰를 유도한다.
+
+```bash
+ORIG_REVIEWERS=$(gh api repos/{owner}/{repo}/pulls/$PR/reviews --jq '[.[].user.login] | unique | .[]')
+for r in $ORIG_REVIEWERS; do
+  [ "$r" = "$ME" ] && continue
+  gh pr edit $PR --add-reviewer $r
+done
+```
+
+반박(REBUT)·보류(HOLD)만 있는 경우 재요청 생략 (리뷰어가 답글 보고 다음 액션 결정).
+
+### 9. Auto-merge 활성화
+
+작성자는 직접 `gh pr merge` 하지 않는다. 대신 **GitHub Auto-merge**를 활성화해서 "모든 조건(리뷰어 approve + 모든 스레드 resolve + CI 통과 + 브랜치 보호 규칙)이 만족되면 자동 병합"되도록 둔다. 병합 트리거는 **리뷰어의 resolve 액션**이 된다.
+
+```bash
+# auto-merge 활성화 (squash 방식)
+gh pr merge $PR --auto --squash --delete-branch
+```
+
+**조건:**
+
+- 이번 실행에 APPLY가 1건 이상 있었거나, 이미 auto-merge 대기 상태가 아닌 경우에만 활성화
+- PR이 draft면 활성화하지 않음 (draft 해제 후 수동으로)
+- 본인 PR이므로 `author == ME` 이미 §1에서 검증됨
+
+**레포 정책:**
+
+- `--squash` 가 기본. 레포가 merge commit을 선호하면 `--merge`, rebase 히스토리를 원하면 `--rebase`로 전환
+- `--delete-branch` 는 병합 후 브랜치 자동 삭제 (레포 기본 설정과 일치하는지 확인)
+
+**auto-merge가 안 되는 케이스 (경고만 출력, 진행은 계속):**
+
+- 레포 브랜치 보호 규칙에서 auto-merge 비활성화됨 → `Auto-merge is not enabled for this repository` 에러 → 리뷰어에게 수동 머지 요청 알림
+- PR이 draft 상태 → 결과 보고에 `AUTO_MERGE_SKIPPED (draft)` 표기
+
+**금지:**
+
+- ❌ `gh pr merge $PR --squash` (즉시 병합, `--auto` 없이) — 작성자 self-merge 금지
+- ❌ 조건 미달인데 강제 병합 시도
+
+### 10. 결과 보고
+
+```
+| 스레드 | 분류 | 원인 커밋 | 답글 | 이모지 | resolve |
+|---|---|---|---|---|---|
+| #N (작성자) | APPLY/REBUT/HOLD | abc1234 / – | ✓ | +1, rocket | ✓ / – |
+```
+
+요약 라인:
+
+```
+PR #N | APPLY=N REBUT=N HOLD=N | rebase: ✓ | force-push: ✓ | re-request: ✓
+```
+
+## Important Rules
+
+- **NEVER 본인이 아닌 PR 처리** — author가 현재 사용자와 다르면 즉시 중단
+- **NEVER `git push --force`** — 항상 `--force-with-lease`
+- **NEVER main/master 브랜치 force-push** — 보호 브랜치 절대 금지
+- **NEVER `--no-verify`** — pre-commit hook 우회 금지. 실패 시 fix 후 재시도
+- **NEVER `git rebase --skip`** — rebase 충돌은 자동 해결하지 않고 사용자에게 알린다
+- **ALWAYS rebase로 원래 커밋 직접 수정** — "fix: review feedback" 류의 추가 커밋 만들지 말 것. 단 원인 커밋이 PR 범위 밖일 때만 예외
+- **ALWAYS 반박·보류는 근거 자료 2개 이상** — 부족하면 반영으로 전환
+- **ALWAYS 답글은 한글, 존댓말, 차분하게** — 감정적 표현 금지
+- **ALWAYS 반영 후 답글에 커밋 SHA 인용** — 어느 커밋에 반영됐는지 추적 가능하게
+- **ALWAYS `pr-review`의 이모지 정책 준용** — `confused`, `-1` 등 부정 이모지 금지
+- **NEVER 작성자가 resolve** — 예외 없음. 오타·포맷·린트 같은 단순 변경이라도 resolve는 리뷰어만. 작성자는 답글 + 커밋 SHA 인용까지만
+- **NEVER 직접 merge** — `gh pr merge --squash` 류 즉시 병합 금지. 병합은 리뷰어의 resolve + 조건 만족으로 트리거되는 auto-merge로만 이뤄진다
+- **ALWAYS auto-merge 활성화** — APPLY가 1건 이상이면 §9 `gh pr merge --auto --squash --delete-branch` 로 예약. draft PR이면 스킵. 레포가 auto-merge 비활성이면 경고 출력

--- a/.claude/skills/pr-review-apply/SKILL.md
+++ b/.claude/skills/pr-review-apply/SKILL.md
@@ -206,6 +206,60 @@ gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/reactions -X POST -f con
 
 resolve는 **하지 않는다** — 리뷰어가 답글 확인 후 동의/재반박 결정.
 
+### 5.1. 의견 충돌 종결 프로토콜 (작성자 우선)
+
+리뷰어 재반박에 답글 왕복이 길어지면 무한 토론 대신 **회차 한도에서 작성자 입장으로 종결**한다.
+
+**라운드 한도**
+
+§2의 `reviewThreads.comments`로 발언자별 코멘트 수를 센다.
+
+- **나(작성자)의 답글 ≤ 2회**
+- **리뷰어 발언 ≤ 2회** (정책 — `pr-review` §8.3.1과 미러)
+
+내 답글이 2회에 도달했는데 리뷰어가 또 답글을 보내왔다면, 그 내용을 **새 근거 평가**만 한 뒤 종결한다.
+
+**REBUT_FINAL 처리**
+
+리뷰어 마지막 답글 평가:
+
+| 결과                                  | 처리                                  |
+| ------------------------------------- | ------------------------------------- |
+| 새 코드 인용·룰·외부 문서가 있고 타당 | 분류 변경: **반영(APPLY)**, §4로 진행 |
+| 같은 주장의 반복이거나 새 근거 부족   | **반박 종결(REBUT_FINAL)** 답글 1회   |
+
+REBUT_FINAL 답글 형식:
+
+```
+앞서 드린 답글의 근거에서 추가로 보강할 자료는 없습니다. 이번 PR은 현재 구현을 유지하고 머지하겠습니다. 추가 논의는 별도 이슈로 이어가면 감사하겠습니다.
+
+(선택) **후속**
+- <별도 이슈/PR 링크 또는 "별도 이슈 발행 예정">
+```
+
+- 한글, 존댓말, 차분한 톤
+- 이모지: `eyes` 1개
+- **resolve는 하지 않는다** — 리뷰어가 `pr-review` §8.3.1에 따라 종결 답글 후 resolve 처리
+
+**예외 — BLOCKED (작성자 우선 적용 금지)**
+
+리뷰어 코멘트가 다음에 해당하면 REBUT_FINAL로 마무리하지 말고 사용자(인간)에게 보고하고 중단:
+
+- 라인 코멘트가 `[P1]` 접두사 (실제 버그·기능 회귀)
+- 본문에 `SQL injection`, `XSS`, `secret`, `token`, `auth`, `데이터 손실`, `data loss`, `breaking change`, `compliance`, `법적` 등 키워드 포함
+- 빌드/CI 실패 우려 명시 (예: "이렇게 두면 빌드 실패")
+
+BLOCKED 시 §9 auto-merge 활성화도 **스킵**한다. 결과 테이블에 `BLOCKED (P1 합의 실패)` 표기.
+
+**처리 흐름 요약**
+
+```
+새 근거 있고 타당 → 반영(APPLY) §4
+새 근거 없음 + 내 답글 < 2회 → 반박(REBUT) §5 (근거 보강)
+새 근거 없음 + 내 답글 ≥ 2회 + P2/P3 → REBUT_FINAL 답글 1회, auto-merge 유지
+P1/보안/CI 우려 → BLOCKED, 사용자 보고, auto-merge 스킵
+```
+
 ### 6. 보류(HOLD) 처리
 
 코드 수정 없음. 답글에 필요한 정보 명시.
@@ -272,6 +326,7 @@ gh pr merge $PR --auto --squash --delete-branch
 
 - 이번 실행에 APPLY가 1건 이상 있었거나, 이미 auto-merge 대기 상태가 아닌 경우에만 활성화
 - PR이 draft면 활성화하지 않음 (draft 해제 후 수동으로)
+- **BLOCKED 스레드가 1건도 없을 때만 활성화** (§5.1 예외 — P1·보안·데이터 손실·CI 실패 우려)
 - 본인 PR이므로 `author == ME` 이미 §1에서 검증됨
 
 **레포 정책:**
@@ -283,24 +338,104 @@ gh pr merge $PR --auto --squash --delete-branch
 
 - 레포 브랜치 보호 규칙에서 auto-merge 비활성화됨 → `Auto-merge is not enabled for this repository` 에러 → 리뷰어에게 수동 머지 요청 알림
 - PR이 draft 상태 → 결과 보고에 `AUTO_MERGE_SKIPPED (draft)` 표기
+- BLOCKED 스레드 존재 → 결과 보고에 `AUTO_MERGE_SKIPPED (BLOCKED)` 표기, 사용자에게 합의 실패 항목 보고
 
 **금지:**
 
 - ❌ `gh pr merge $PR --squash` (즉시 병합, `--auto` 없이) — 작성자 self-merge 금지
 - ❌ 조건 미달인데 강제 병합 시도
 
+### 9.5. 회고록 작성 (CLAUDE.local.md)
+
+반영(APPLY)된 리뷰 코멘트는 같은 실수를 반복하지 않도록 **현재 레포의 `CLAUDE.local.md`에 회고록을 누적 작성**한다.
+
+**대상 파일**
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LOCAL_MD="$REPO_ROOT/CLAUDE.local.md"
+[ -f "$LOCAL_MD" ] || touch "$LOCAL_MD"
+```
+
+워크스페이스 루트가 아닌 **개별 레포 루트**의 `CLAUDE.local.md`를 사용한다 (예: `buzzle-editor/CLAUDE.local.md`).
+
+**기록 대상**
+
+- **반영(APPLY)** 으로 분류된 모든 코멘트 → 필수
+- **BLOCKED** 항목 → 필수 (`사용자 판단 대기` 표기)
+- **REBUT / REBUT_FINAL / HOLD** → 선택 (같은 지적 재발 시 근거 빨리 찾기 위함)
+
+**기록 형식 (append, 새 PR마다 새 섹션)**
+
+```markdown
+## 리뷰 회고 — YYYY-MM-DD PR #<번호> (<제목>)
+
+### [P<n>] <파일:라인 또는 짧은 주제>
+
+**받은 지적**
+
+> <리뷰 코멘트 핵심 1~2문장>
+
+**원인**
+<왜 이런 코드를 썼는지 — 룰 미숙지·패턴 부재·검토 부족 등 솔직하게>
+
+**적용한 변경**
+<무엇을 어떻게 바꿨는지 + 커밋 SHA>
+
+**다음부터**
+<체크 가능한 행동 1~2개>
+```
+
+**작성 원칙**
+
+- **솔직한 원인** — "단순 실수" 같은 면피성 표현 금지. 구체적 인지 실패 지점을 적는다 (예: "`predictability.mdc` 룰을 안 읽음", "기존 패턴 grep 안 함", "unknown 처리 룰을 모름")
+- **체크 가능한 다음 액션** — "조심하겠다" 류 다짐 금지. 행동으로 (예: "PR 작업 전 `.claude/rules/*.mdc` 1회 읽기", "새 컴포넌트 시작 전 `grep -r \"useQuery\" src/components` 실행")
+- **append-only** — 기존 회고 수정·삭제 금지. 새 PR마다 끝에 추가
+- **PR 브랜치에 커밋하지 않는다** — `.gitignore`에 `CLAUDE.local.md` 포함 여부 확인. 누락 시 1회 안내: "개인 메모이므로 `.gitignore`에 `CLAUDE.local.md` 추가를 권장합니다." (스킬은 자동으로 add 하지 않는다)
+- **용량 관리** — 50KB 초과 시 사용자에게 알리고 오래된 회고를 별도 파일(`docs/review-retro/<year>-<quarter>.md` 등)로 옮기도록 제안 (자동 이동 안 함)
+
+**예시**
+
+```markdown
+## 리뷰 회고 — 2026-04-30 PR #234 (feat: 사용자 프로필 카드)
+
+### [P2] src/components/ProfileCard.tsx:45
+
+**받은 지적**
+
+> `useEffect` 안에서 `fetch` 직접 호출 — `useQuery` 훅 패턴이 이 레포 표준
+
+**원인**
+`.claude/rules/data-fetching.mdc`를 읽지 않고 작업. 다른 컴포넌트에서 어떻게 fetch 하는지 grep 안 함.
+
+**적용한 변경**
+`useQuery(["profile", id], fetchProfile)` 로 교체 (커밋 a1b2c3d). 캐싱·refetch 정책도 표준 옵션 적용.
+
+**다음부터**
+
+- 데이터 페칭 코드 작성 전 `.claude/rules/data-fetching.mdc` 읽기
+- 새 컴포넌트 시작 전 `grep -r "useQuery" src/components` 로 기존 패턴 1개 확인
+```
+
+**스킵 조건**
+
+- APPLY와 BLOCKED 모두 0건이면 회고 스킵 가능
+- `git rev-parse --show-toplevel` 실패(워크스페이스 루트 등 Git 리포 아님) → 스킵하고 사용자에게 "개별 레포로 이동 후 다시 실행" 안내
+
+회고 작성 결과(추가 엔트리 수, `.gitignore` 안내 발생 여부)는 §10 결과 보고에 포함한다.
+
 ### 10. 결과 보고
 
 ```
-| 스레드 | 분류 | 원인 커밋 | 답글 | 이모지 | resolve |
-|---|---|---|---|---|---|
-| #N (작성자) | APPLY/REBUT/HOLD | abc1234 / – | ✓ | +1, rocket | ✓ / – |
+| 스레드 | 분류 | 원인 커밋 | 답글 | 이모지 | resolve | retro |
+|---|---|---|---|---|---|---|
+| #N (작성자) | APPLY/REBUT/HOLD/REBUT_FINAL/BLOCKED | abc1234 / – | ✓ | +1, rocket | – (작성자 안 함) | ✓ / – |
 ```
 
 요약 라인:
 
 ```
-PR #N | APPLY=N REBUT=N HOLD=N | rebase: ✓ | force-push: ✓ | re-request: ✓
+PR #N | APPLY=N REBUT=N HOLD=N REBUT_FINAL=N BLOCKED=N | rebase: ✓ | force-push: ✓ | re-request: ✓ | retro: ✓ (N entries) | auto-merge: ✓ / SKIPPED(<reason>)
 ```
 
 ## Important Rules
@@ -318,3 +453,5 @@ PR #N | APPLY=N REBUT=N HOLD=N | rebase: ✓ | force-push: ✓ | re-request: ✓
 - **NEVER 작성자가 resolve** — 예외 없음. 오타·포맷·린트 같은 단순 변경이라도 resolve는 리뷰어만. 작성자는 답글 + 커밋 SHA 인용까지만
 - **NEVER 직접 merge** — `gh pr merge --squash` 류 즉시 병합 금지. 병합은 리뷰어의 resolve + 조건 만족으로 트리거되는 auto-merge로만 이뤄진다
 - **ALWAYS auto-merge 활성화** — APPLY가 1건 이상이면 §9 `gh pr merge --auto --squash --delete-branch` 로 예약. draft PR이면 스킵. 레포가 auto-merge 비활성이면 경고 출력
+- **ALWAYS 의견 충돌 종결 프로토콜** — 같은 스레드에서 내 답글이 2회에 도달했는데 합의 안 되면 REBUT_FINAL 답글 1회로 마무리(§5.1). resolve는 여전히 안 함(리뷰어 몫). P1·보안·데이터 손실·CI 실패 우려는 `BLOCKED`으로 사용자에게 보고하고 §9 auto-merge 활성화도 스킵
+- **ALWAYS APPLY/BLOCKED는 CLAUDE.local.md 회고록에 기록** — 같은 실수 반복 방지(§9.5). 솔직한 원인 + 체크 가능한 다음 액션 필수. `.gitignore`에 `CLAUDE.local.md` 누락 시 1회 안내. Git 리포가 아니면(워크스페이스 루트) 스킵

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,509 @@
+---
+name: pr-review
+description: Pn 규칙(P1-P5) 기반 GitHub PR 라인별 코드 리뷰. Use when the user says "pr-review", "리뷰", "review", "코드 리뷰", "PR 리뷰", or wants to review pull requests.
+---
+
+Pn 규칙 기반 GitHub PR 라인별 리뷰를 수행한다.
+
+## Pn 규칙 (뱅크샐러드 코드 리뷰 문화)
+
+| 레벨 | 의미                     | 리뷰어 의도                        |
+| ---- | ------------------------ | ---------------------------------- |
+| P1   | 꼭 반영해 주세요         | 머지 전 필수 수정                  |
+| P2   | 적극적으로 고려해 주세요 | 권장, 합리적 이유 있으면 패스 가능 |
+| P3   | 고려해 주세요            | 의견 제시, 무시 가능               |
+| P4   | 사소한 것 (Nit)          | 오타, 스타일 등                    |
+| P5   | 칭찬해요                 | 잘한 점 인정                       |
+
+## Steps
+
+### 1. 리뷰 대상 파악
+
+```bash
+# 열린 PR 목록 확인
+gh pr list --state open --json number,title,author,headRefName --jq '.[] | {number, title, author: .author.login, branch: .headRefName}'
+
+# 현재 사용자 확인
+gh api user --jq '.login'
+```
+
+사용자가 특정 PR 번호를 지정하면 해당 PR만 리뷰. 지정하지 않으면 내가 올린 PR을 제외한 모든 열린 PR을 대상으로 한다.
+
+**⚠️ 리뷰어 지정 필수**: PR의 요청된 리뷰어(`reviewRequests`) 목록에 현재 사용자(`gh api user --jq '.login'`)가 포함되지 않은 경우 **리뷰하지 않는다.** 명시적으로 나를 지목한 PR만 리뷰한다. 결과 테이블에 `SKIPPED (리뷰어 아님)`으로 표시.
+
+```bash
+# 내가 리뷰어로 지정됐는지 확인
+gh pr view <number> --json reviewRequests --jq '.reviewRequests[].login' | grep -Fx "$(gh api user --jq '.login')"
+```
+
+**⚠️ 자기 PR 리뷰 절대 금지**: PR의 `author.login`이 현재 사용자(`gh api user --jq '.login'`)와 같으면 **어떤 경우에도 리뷰하지 않는다.** 사용자가 명시적으로 번호를 지정하더라도 자기 PR이면 스킵하고 결과 테이블에 `SKIPPED (본인 PR)`로 표시한다. 본인이 본인 PR에 approve/request_changes를 다는 것은 셀프 승인이므로 정책적으로 허용하지 않는다.
+
+### 1.5. 이전 리뷰 상태 확인 (중복 리뷰 방지)
+
+각 PR에 대해 이전에 내가 작성한 리뷰가 있는지, 그 이후로 변경이 있었는지 확인한다.
+
+```bash
+# 내가 쓴 가장 최근 리뷰의 commit_id 조회
+MY_LOGIN=$(gh api user --jq '.login')
+LAST_REVIEWED_SHA=$(gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq "[.[] | select(.user.login==\"$MY_LOGIN\")] | last | .commit_id")
+
+# 현재 PR HEAD SHA
+CURRENT_SHA=$(gh pr view <number> --json headRefOid --jq '.headRefOid')
+```
+
+- `LAST_REVIEWED_SHA == CURRENT_SHA` → 마지막 리뷰 이후 변경 없음 → **해당 PR 리뷰 스킵**, 결과 테이블에 `SKIPPED (변경 없음)` 표시. Step 9로 이동.
+- `LAST_REVIEWED_SHA` 없음 (첫 리뷰) 또는 SHA가 다름 → Step 2로 진행.
+
+### 1.6. PR 스킬 준수 여부 점검
+
+리뷰 시작 전 PR이 `pr` 스킬 표준에 맞게 만들어졌는지 확인한다. 위반 시 작성자에게 `pr` 스킬 사용을 권장하는 일반 코멘트(이슈 코멘트, 라인 X)를 1회 남긴다. 이미 동일 안내 코멘트가 있으면 중복 등록하지 않는다.
+
+```bash
+gh pr view <number> --json labels,assignees,reviewRequests,body --jq '{labels:[.labels[].name], assignees:[.assignees[].login], reviewers:[.reviewRequests[].login], body}'
+```
+
+**위반 판정 (하나라도 해당):**
+
+- `type:*` 라벨이 정확히 1개가 아님 (없거나 2개 이상)
+- `mode:*` 라벨이 정확히 1개가 아님
+- assignee가 비어있음 (작성자 self-assign 미적용)
+- reviewer가 비어있음 (리뷰 요청 누락)
+- 본문이 PR 템플릿(Summary / Impact / Checks / Review Focus 섹션)을 따르지 않음
+
+**안내 코멘트 예시 (이슈 코멘트로 등록):**
+
+```bash
+gh api repos/{owner}/{repo}/issues/<number>/comments -X POST -f body="이 PR은 \`/pr\` 스킬을 사용해서 만든 흔적이 없어 보입니다. 다음 항목이 누락/이상합니다: <목록>. 다음부터는 PR 생성 시 \`/pr\` 스킬을 사용해 주세요. 이번 PR은 \`gh pr edit\` 또는 GitHub UI에서 라벨/assignee/리뷰어/본문 템플릿을 보정 부탁드립니다."
+```
+
+체크 결과는 결과 테이블의 `pr-skill` 컬럼에 `OK` / `WARN(N개 누락)` 으로 표기.
+
+### 1.7. 프로젝트 룰 로드
+
+해당 레포의 `.claude/rules/**/*.mdc` (또는 `*.md`)를 **리뷰 시작 전에 반드시 읽는다**. 룰이 있으면 리뷰 판단 기준에 함께 적용한다.
+
+```bash
+ls .claude/rules/ 2>/dev/null
+# 파일이 있으면 전부 cat/Read로 로드
+```
+
+- 룰 파일이 없는 레포(예: `buzzle-system`, `bds`)는 스킵 — 프로젝트 CLAUDE.md/AGENTS.md만 참고
+- 룰 파일이 있으면 **각 룰의 요구사항을 P1~P3 판정 근거로 활용**한다. 룰 위반이 머지 블록급이면 P1, 권장 수준이면 P2, 의견 제시면 P3
+- 라인 코멘트에 룰을 인용할 땐 룰 이름을 명시 (예: `[P2] predictability.mdc 위반 — ...`)
+
+### 2. PR diff 분석
+
+각 PR에 대해:
+
+```bash
+# 커밋 SHA
+gh pr view <number> --json headRefOid --jq '.headRefOid'
+
+# 변경 파일 목록
+gh pr diff <number> --name-only
+
+# 전체 diff
+gh pr diff <number>
+```
+
+diff를 읽고 다음을 파악한다:
+
+- 무엇이 변경되었고 왜
+- 기존 프로젝트 패턴과의 일관성
+- 잠재적 버그나 엣지케이스
+
+### 3. 리뷰 판단 기준
+
+**중요: 억지로 문제를 찾지 않는다.** 진짜 문제만 지적한다.
+
+- 실제 버그, 기능 회귀 → P1
+- 컨벤션 위반 (ESLint 룰 실패 등) → P1 또는 P2
+- 패턴 불일치, 개선 권장 → P2 또는 P3
+- 코드 중복, 리팩토링 제안 → P3
+- 오타, 네이밍, 스타일 → P4
+- 잘 작성된 코드, 좋은 설계 → P5
+
+**P5 칭찬 코멘트를 반드시 포함한다.** 잘한 점을 인정하는 것도 리뷰의 중요한 부분이다.
+
+### 4. 리뷰 결과 판정
+
+뱅크샐러드 코드 리뷰 문화(https://blog.banksalad.com/tech/banksalad-code-review-culture/) 기준을 따른다.
+
+- **P1·P2·P3 중 하나라도 있으면** → `REQUEST_CHANGES`
+- **P4·P5만 있거나 아무 이슈도 없으면** → `APPROVE`
+
+즉 `APPROVE`는 "P4/P5만 존재하는 경우"에만 허용된다. P2(적극 고려)·P3(고려)가 남아있으면 무조건 `REQUEST_CHANGES` — 작성자가 반영 또는 의견 교환 후 재리뷰받도록 한다.
+
+### 5. GitHub 리뷰 생성
+
+`gh api`로 라인별 코멘트가 포함된 리뷰를 생성한다.
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --method POST \
+  -f commit_id="<SHA>" \
+  -f body="<리뷰 요약>" \
+  -f event="<REQUEST_CHANGES|APPROVE>" \
+  -f 'comments[0][path]=<file>' \
+  -f 'comments[0][line]=<line_number>' \
+  -f 'comments[0][side]=RIGHT' \
+  -f 'comments[0][body]=[P1] 설명...'
+```
+
+**`line`은 변경 후 파일의 실제 라인 번호**이다. diff의 `+` 라인에서 `@@ -a,b +c,d @@` 헤더를 기준으로 계산한다.
+
+**⚠️ 모든 Pn 코멘트(P1~P5)는 반드시 라인 코멘트로 등록한다.** body에 나열해 두는 것은 금지. 라인 번호 계산은 리뷰어의 책임이며 건너뛰어서는 안 된다. P5 칭찬도 어떤 코드/라인이 좋은지 그 라인에 달아야 한다.
+
+- 라인 번호 계산법:
+    1. `gh pr diff <n>` 에서 해당 파일 hunk의 `@@ -a,b +c,d @@` 헤더를 찾는다
+    2. `c`부터 시작해서 hunk 내 ` `(context) 및 `+`(added) 라인을 세며 대상 라인까지 내려간다 (`-`는 카운트 안 함)
+    3. 그 숫자가 `line` 값
+- diff에 나타나지 않은(변경 없는) 라인을 가리켜야 하는 경우에는 `line`이 허용되지 않는다. 이 경우 **가장 가까운 변경 라인**을 지정하고 코멘트 본문에서 "참고: L123 근처"처럼 명시한다
+- 다중 라인 범위가 필요하면 `start_line` + `line` + `start_side=RIGHT` + `side=RIGHT` 사용
+- 라인 단위로 붙일 수 없는 **구조적/전체적 논평**(예: 파일 구성, 아키텍처)만 body에 둔다. 구체 코드에 대한 지적은 반드시 라인 코멘트
+
+### 6. 리뷰 본문(body) 형식
+
+```
+### 리뷰 요약
+(잘한 점과 개선 사항을 간결하게 — P5 먼저, 이슈 나중)
+```
+
+### 7. 라인 코멘트 형식
+
+각 코멘트는 `[Pn]` 접두사로 시작한다:
+
+```
+[P1] 설명 — 왜 문제인지, 어떻게 고치면 좋은지
+[P5] 🎉 칭찬 — 구체적으로 무엇이 좋은지
+```
+
+- 한글로 작성
+- 문제 코멘트: 원인 + 개선 방안 상세 설명
+- 칭찬 코멘트: 구체적으로 무엇이 좋은지 설명. **본문에 반드시 이모지를 1개 이상 포함한다** (예: 🎉 👏 ✨ 🔥 💯 🙌 👍 🚀). 분위기에 맞게 자연스럽게 섞어 쓴다.
+
+**로직 수정 제안 시 Before/After 코드 필수**
+
+코드 로직 변경을 제안하는 모든 P1·P2·P3 코멘트에는 아래 형식으로 **변경 전/후 코드 블록**을 반드시 포함한다. 단순 네이밍/오타(P4)나 칭찬(P5)은 제외.
+
+````markdown
+[P2] <설명 — 무엇이 문제이고 왜 바뀌어야 하는지>
+
+**Before**
+
+```ts
+const foo = items.filter((i) => i.active).map((i) => i.id)[0];
+```
+
+**After**
+
+```ts
+const foo = items.find((i) => i.active)?.id;
+```
+
+<선택: 추가 설명, 트레이드오프, 대안>
+````
+
+- 언어 태그는 실제 파일 확장자에 맞춘다 (`ts`, `tsx`, `js`, `jsx`, `css`, `prisma` 등)
+- Before는 현재 PR의 해당 라인을 **그대로** 인용한다 (임의 생략/단순화 금지)
+- After는 실제로 동작하는 코드여야 한다 — 타입/임포트/시그니처가 프로젝트 패턴과 일치하는지 확인
+- GitHub [suggestion 블록](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request)( ` ```suggestion `)을 쓸 수 있는 케이스(단일 라인 대체)면 After 대신 suggestion 블록을 사용해도 좋다
+
+### 8. 이모지 반응
+
+PR 본문(작성자의 글)에 이모지 반응을 추가한다:
+
+```bash
+# APPROVE한 PR
+gh api repos/{owner}/{repo}/issues/{number}/reactions --method POST -f content="+1"
+gh api repos/{owner}/{repo}/issues/{number}/reactions --method POST -f content="rocket"
+
+# REQUEST_CHANGES한 PR
+gh api repos/{owner}/{repo}/issues/{number}/reactions --method POST -f content="eyes"
+```
+
+**자기 코멘트에 자기가 이모지를 달지 않는다.** 상대방의 글(PR 본문)에만 반응한다.
+
+### 8.3. 내 리뷰에 달린 답글 대응 (토론 이어가기)
+
+내가 남긴 리뷰 코멘트에 **다른 사람이 질문하거나 반박**한 스레드가 있으면, 코드를 다시 정밀 분석하고 답글을 단다.
+
+```bash
+# 1) 모든 리뷰 스레드 + 코멘트 작성자/내용 조회
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first:50) {
+              nodes {
+                databaseId
+                author { login }
+                body
+                createdAt
+                path
+                line
+              }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner={owner} -F repo={repo} -F number=<number>
+```
+
+**대응 대상 스레드 판별:**
+
+- `isResolved == false` **그리고** `isOutdated == false`
+- 스레드 첫 코멘트 작성자 == 나 (내가 시작한 스레드)
+- **마지막 코멘트 작성자 ≠ 나** (상대가 마지막으로 말했고 내가 아직 답하지 않음)
+- 상대 코멘트 본문이 질문(`?`, "왜", "근거", "이유", "확인", "맞나요" 등) 또는 반박("아닙니다", "이게 맞", "의도한", "필요", "다름", "하지만" 등)으로 해석됨
+
+**재분석 후 답글 작성:**
+
+1. 해당 파일·라인과 주변 맥락을 다시 읽는다 (`gh pr diff` + 필요하면 원본 파일 fetch).
+2. 상대 의견이 타당한지 판단한다.
+    - **타당하면**: 내 이전 판단을 철회하고 인정한다. 이후 해당 스레드는 resolve 해도 된다.
+    - **타당하지 않으면**: 구체적 근거(라인 번호, 코드 인용, 패턴 참조)를 들어 재반박한다.
+    - **판단 보류**: 추가 정보가 필요하면 무엇이 필요한지 명시해서 되묻는다.
+3. 답글은 스레드에 댓글로 추가 (리뷰 이벤트가 아닌 개별 댓글):
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies \
+  --method POST \
+  -f body="<답글 본문>"
+```
+
+**답글 톤 & 형식:**
+
+- 한글, 존댓말, 차분하고 근거 중심
+- 인정할 때는 명확히 인정 (`말씀대로 ~ 맞습니다. 제 이전 코멘트는 철회합니다.`)
+- 반박할 때는 `[Pn]` 접두사 사용하지 않음 (리뷰 등급이 아닌 토론)
+- 감정적 표현, 단정적 어조 피함
+- 필요시 관련 파일/라인 인용으로 근거 제시
+
+**하지 않는 일:**
+
+- 타인이 시작한 스레드에는 묻지 않은 이상 끼어들지 않는다
+- 내 스레드라도 상대가 아직 답하지 않았는데 먼저 추가 코멘트를 달지 않는다
+- 반박할 때 같은 코드를 피상적으로 다시 설명만 하지 않는다 — **반드시 재분석 후** 근거 보강
+- **무대응 금지** — 작성자가 답글을 보냈는데 내버려두면 auto-merge가 트리거되지 않는다(resolve 안 됨). 반드시 동의·재반박·종결 셋 중 하나로 처리
+
+답글 처리한 스레드 수는 결과 보고에 포함한다.
+
+### 8.3.1. 의견 충돌 종결 프로토콜 (작성자 우선)
+
+토론이 길어지면 무한 왕복 대신 **회차 한도에서 작성자 판단을 존중**하며 종결한다.
+
+**라운드 한도**
+
+§8.3에서 조회한 `reviewThreads.comments`로 각 스레드의 발언자별 코멘트 수를 센다.
+
+- **리뷰어(나)의 발언 ≤ 2회** — 시작 코멘트 + 재반박 1회까지만
+- **작성자의 답글 ≤ 2회**
+
+내 발언이 이미 2회에 도달했는데 작성자가 동의하지 않은 상태로 답글을 또 보내왔다면, **새로운 반박을 만들지 않는다.** 종결 답글 1회 + resolve로 마친다.
+
+**종결 답글 형식**
+
+```
+근거는 앞서 드린 답글에 정리돼 있고, 이번 PR에서 추가로 보강할 자료는 없습니다. 작성자 판단을 존중하고 이 스레드는 종결하겠습니다. 추가 논의는 별도 이슈로 이어가도 좋겠습니다.
+```
+
+- 한글, 존댓말, 차분한 톤
+- `[Pn]` 접두사 사용 안 함
+- 답글 직후 해당 스레드를 **resolve** (내가 단 스레드이므로 §8.4 원칙 안에서 허용)
+- 등급 자동 다운그레이드 없음 — 이번 PR 한정 종결만
+
+**예외 — BLOCKED (작성자 우선 적용 금지)**
+
+다음에 해당하면 회차와 무관하게 종결하지 말고 사용자(인간)에게 보고하고 중단한다:
+
+- 원래 등급이 P1인 항목 (실제 버그·기능 회귀)
+- 보안 취약점·데이터 손실·컴플라이언스/법적 요구사항
+- 빌드/CI 실패가 명확히 예상되는 변경
+
+결과 테이블에 `BLOCKED (P1 합의 실패)` 표기. resolve도 merge도 하지 않는다.
+
+**작성자가 REBUT_FINAL을 보낸 경우 (apply §5.1)**
+
+작성자가 종결 답글(`현재 구현을 유지하고 머지하겠습니다`)을 보냈다면 자동으로 처리되지 않고 **리뷰어가 명시적으로 후속 액션을 한다**:
+
+1. 답글의 근거를 다시 읽고 동의 여부 판단
+2. 판단에 따른 처리:
+
+| 판단                                    | 처리                                                 |
+| --------------------------------------- | ---------------------------------------------------- |
+| 작성자 입장 타당                        | 인정 답글 + resolve (자기 의견 철회)                 |
+| 부당하지만 P2/P3 + 내 발언 ≥ 2회        | 본 §8.3.1 종결 답글 + resolve                        |
+| 부당하고 P1·보안·CI 우려                | `BLOCKED` 표기, 사용자 보고, resolve·merge 모두 보류 |
+| 부당하지만 내 발언 < 2회 + 새 근거 있음 | 재반박 (라운드 한도 내)                              |
+
+**resolve를 빠뜨리지 말 것** — 작성자는 어떤 경우에도 자기 PR 스레드를 resolve하지 않으므로(§8.4), 이 단계에서 리뷰어가 resolve하지 않으면 auto-merge가 영영 트리거되지 않는다.
+
+**처리 흐름 요약**
+
+```
+재분석 → 상대 의견 타당 → 인정·철회·resolve (§8.3)
+재분석 → 부당 + 내 발언 < 2회 → 근거 보강 재반박
+재분석 → 부당 + 내 발언 ≥ 2회 + P2/P3 → 종결 답글 + resolve
+재분석 → 부당 + 내 발언 ≥ 2회 + P1/보안/CI → BLOCKED, 사용자 보고
+```
+
+종결로 resolve한 스레드 수는 결과 보고의 `Yielded` 컬럼에 포함한다.
+
+### 8.4. Resolve 기준 (Conversation 해결 처리)
+
+GitHub PR 스레드의 "Resolve conversation"은 해당 코멘트가 실제로 해결되었는지에 대한 판단이다. **원칙은 리뷰어가 resolve한다** — 판단권은 코멘트를 남긴 사람에게 있다.
+
+**원칙: 리뷰어가 resolve**
+
+- 리뷰어가 지적 → 작성자 수정 → 리뷰어 확인 후 resolve
+- 실제로 반영됐는지 평가할 수 있는 건 코멘트 주인뿐
+
+**예외: 작성자가 resolve해도 되는 경우** (커뮤니케이션 비용 절감)
+
+다음 조건을 **모두** 만족하는 경우에만 허용:
+
+- 오타·포맷·린트 수정 같은 **단순 기계적 변경**
+- 리뷰어 의도가 100% 명확해서 해석 여지가 없음
+- 의견 충돌이 전혀 없음 (질문이나 반박 없이 "고치세요" 수준)
+
+**지양 패턴 (하면 안 됨)**
+
+- ❌ 리뷰어 확인 없이 임의로 작성자가 resolve
+- ❌ 의견 충돌(`[P2]` 이상의 논의)이 남아있는데 resolve
+- ❌ 타인(다른 리뷰어)이 단 스레드를 resolve
+
+**스킬 동작 규칙 (리뷰어 역할 수행 시)**
+
+1. 내가 단 스레드 중 **outdated(라인 변경됨)** 인 경우 → 자동 resolve (§8.5)
+2. 내가 단 스레드 중 **코드 수정은 됐지만 outdated 아님**(같은 라인에서 수정) → 재분석 후 실제로 해결됐으면 resolve, 아니면 "아직 반영 안 됐음" 답글
+3. 내가 안 단 스레드 → **절대 resolve하지 않는다** (판단권 없음)
+4. 작성자가 이미 스스로 resolve한 스레드(`isResolved == true` + 마지막 resolver가 작성자) → 내가 코멘트 주인이면 재분석해서 실제 해결 여부 확인, 아니면 스킵
+
+### 8.7. 병합 (Merge) 조건
+
+**원칙: 검증한 사람이 배포 트리거를 건다.** 리뷰어가 직접 병합하는 것을 표준으로 삼는다. 단 모든 조건을 만족할 때만 가능하다.
+
+**병합 허용 조건 (모두 만족해야 함):**
+
+1. **이번 리뷰 결과가 `APPROVE`** — REQUEST_CHANGES면 절대 금지
+2. **모든 리뷰 스레드가 resolved** — 내 것뿐 아니라 다른 리뷰어/작성자가 단 스레드 전부 `isResolved == true`
+3. **CI 전부 통과** — `gh pr checks <number>` 결과 fail/pending 0개
+4. **PR이 mergeable 상태** — `gh pr view <n> --json mergeable,mergeStateStatus` 가 `MERGEABLE` + `CLEAN`/`HAS_HOOKS`
+5. **다른 리뷰어가 모두 approve** (있는 경우) — 추가 리뷰어가 지정돼 있는데 아직 approve 안 했으면 대기
+6. **approve 이후 새 커밋 없음** — approve 시점 SHA == 현재 headRefOid. 다르면 재리뷰 필요
+7. **본인 PR 아님** — 자기 PR은 절대 self-merge 금지 (§1 자기 PR 리뷰 금지 규칙과 동일)
+
+**조건 확인 명령:**
+
+```bash
+PR=<number>
+APPROVED=$(gh api repos/{owner}/{repo}/pulls/$PR/reviews --jq "[.[] | select(.user.login==\"$(gh api user --jq .login)\" and .state==\"APPROVED\")] | last | .commit_id")
+HEAD=$(gh pr view $PR --json headRefOid --jq .headRefOid)
+CHECKS=$(gh pr checks $PR --json state --jq '[.[] | select(.state!="SUCCESS" and .state!="NEUTRAL" and .state!="SKIPPED")] | length')
+MERGEABLE=$(gh pr view $PR --json mergeable,mergeStateStatus --jq "[.mergeable, .mergeStateStatus] | @tsv")
+UNRESOLVED=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}' -F o={owner} -F r={repo} -F n=$PR --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')
+
+# 모든 조건 만족 시
+if [ "$APPROVED" = "$HEAD" ] && [ "$CHECKS" = "0" ] && [ "$UNRESOLVED" = "0" ]; then
+  gh pr merge $PR --squash --delete-branch
+fi
+```
+
+**병합 방식:** 기본 `--squash`(commit history 단순화). 레포 정책이 다르면 따른다 (`--merge` / `--rebase`).
+
+**금지:**
+
+- ❌ 조건 하나라도 불충족 시 병합 — 절대 금지
+- ❌ 본인 PR self-merge — 권한 있어도 금지
+- ❌ approve 없이 작성자 권유로 merge — "확인 안 한 사람이 배포 트리거 당김" 문제
+- ❌ 리뷰 진행 중인데 merge — 다른 리뷰어 의견 차단
+
+**예외:** 사용자가 명시적으로 "merge 하지 마"라고 한 경우(예: 기능 플래그 대기, 일정 조율) 조건 만족해도 merge 보류하고 결과 테이블에 `MERGE_HELD (사유)` 표기.
+
+병합한 PR은 결과 테이블의 `Merged` 컬럼에 `✓` 로 표기.
+
+### 8.5. 오래된 리뷰 스레드 자동 정리 (outdated resolve)
+
+코드 변경으로 더 이상 유효하지 않은 **내 이전 리뷰 코멘트**를 자동 resolve 한다. 다른 사람의 스레드는 건드리지 않는다.
+
+```bash
+# 1) PR의 모든 리뷰 스레드를 GraphQL로 조회 (outdated/resolved/author 정보 포함)
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            comments(first:1) { nodes { author { login } } }
+          }
+        }
+      }
+    }
+  }' -F owner={owner} -F repo={repo} -F number=<number>
+
+# 2) 내가 쓴 & isOutdated=true & isResolved=false 인 스레드의 id 추출
+# 3) 각 스레드를 resolve
+gh api graphql -f query='
+  mutation($threadId:ID!) {
+    resolveReviewThread(input:{threadId:$threadId}) {
+      thread { id isResolved }
+    }
+  }' -F threadId=<thread_id>
+```
+
+**판단 기준:**
+
+- `isOutdated == true` → 해당 라인이 이후 변경됨 → 내 이전 코멘트가 더 이상 유효하지 않음 → **resolve**
+- `isOutdated == false` → 라인이 그대로 → 아직 유효 → 건드리지 않음
+- `isResolved == true` → 이미 resolve → 스킵
+- 내가 쓴 스레드가 아님 → 건드리지 않음 (**타인 리뷰 임의 resolve 금지**)
+
+**삭제는 하지 않는다.** Resolve 처리만 한다 (이력 보존).
+
+Resolve한 스레드 수를 결과 보고에 포함한다.
+
+### 9. 결과 보고
+
+리뷰 완료 후 요약 테이블을 출력한다:
+
+```
+| PR | 결과 | pr-skill | P1 | P5 | Replied | Resolved | Merged | 링크 |
+|---|---|---|---|---|---|---|---|---|
+| #N (작성자) | APPROVE / REQUEST_CHANGES / SKIPPED | OK / WARN(N) | N건 | N건 | N건 | N개 | ✓ / – / HELD | 리뷰 링크 |
+```
+
+- `SKIPPED`는 "마지막 리뷰 이후 변경 없음" 또는 "본인 PR" 케이스
+- `Replied`는 이번 실행에서 재분석 후 답글을 단 내 이전 스레드 개수
+- `Resolved`는 이번 실행에서 outdated로 판단되어 자동 resolve된 내 이전 스레드 개수
+
+## Important Rules
+
+- **ALWAYS 로직 수정 제안(P1~P3)에는 Before/After 코드 블록을 포함한다** — 단순 네이밍·오타(P4), 칭찬(P5) 제외
+- **ALWAYS 해당 레포의 `.claude/rules/**/\*.mdc`를 리뷰 전에 로드하고 판정 근거로 인용한다\*\* — 룰 파일이 없는 레포는 CLAUDE.md/AGENTS.md만 참고
+- **NEVER 내가 안 단 스레드를 resolve하지 않는다** — resolve 판단권은 코멘트 주인의 몫. 자동 resolve는 내가 단 스레드 + outdated(§8.5) 한정
+- **NEVER 리뷰어로 지정되지 않은 PR은 리뷰하지 않는다** — PR `reviewRequests`에 현재 사용자가 포함된 경우에만 리뷰. 아니면 스킵.
+- **NEVER 자기 PR은 리뷰하지 않는다** — PR `author.login`이 현재 사용자와 같으면 명시 지정되었더라도 스킵. 셀프 approve/request_changes 금지.
+- **MERGE 조건부 허용** — 다음 모든 조건을 만족할 때만 리뷰어가 직접 `gh pr merge` 한다(§8.7): ①이번 리뷰 APPROVE, ②모든 스레드 resolved, ③CI 전부 SUCCESS, ④mergeable=MERGEABLE, ⑤다른 리뷰어 전원 approve, ⑥approve 이후 새 커밋 없음, ⑦본인 PR 아님. 하나라도 불충족이면 절대 merge 금지. 사용자가 "merge 하지 마"라고 명시한 경우 보류.
+- **ALWAYS PR 스킬 준수 점검** — 리뷰 시작 전 `/pr` 스킬 표준(`type:*`/`mode:*` 라벨 각 1개, assignee, reviewer, 본문 템플릿) 점검(§1.6). 누락 시 작성자에게 일반 코멘트로 `/pr` 스킬 사용 권장 메시지를 1회 등록(중복 방지). 결과 테이블 `pr-skill` 컬럼에 OK/WARN 표기.
+- **NEVER** CRITICAL/HIGH/MEDIUM/LOW 등급 사용 — 반드시 P1~P5만 사용
+- **NEVER** 억지로 문제를 만들어내지 않는다 — 문제 없으면 P5만 달고 APPROVE
+- **ALWAYS** P5 칭찬 코멘트를 포함한다
+- **ALWAYS** 라인별 코멘트를 사용한다 — **P1~P5 모든 Pn 코멘트**를 예외 없이 `comments[]`의 라인 코멘트로 등록한다. P5 칭찬도 해당 라인에 단다. 리뷰 body에 나열 금지. 라인 번호 계산 부담을 이유로 body에 몰아넣지 않는다. body는 총평(P5로 시작하는 요약 + 이슈 요약)만 담는다
+- **ALWAYS** 한글로 작성한다
+- **ALWAYS** PR 본문에 이모지 반응을 추가한다
+- **NEVER** 자기 코멘트에 자기가 이모지를 달지 않는다
+- P1 판정은 신중하게 — 실제로 머지하면 안 되는 이유가 있을 때만
+- AI 생성 코드 리뷰 시 할루시네이션(존재하지 않는 API/타입 사용)과 기존 패턴 무시를 중점으로 확인
+- **ALWAYS 의견 충돌 종결 프로토콜** — 같은 스레드에서 내 발언이 2회에 도달했는데도 합의 안 되면, 새 반박 대신 "작성자 판단을 존중하겠습니다" 종결 답글 1회 + resolve로 마무리(§8.3.1). P1·보안·데이터 손실·CI 실패 우려는 `BLOCKED`으로 사용자에게 보고하고 resolve·merge 모두 보류
+- **ALWAYS 작성자 답글에 대응** — 작성자가 답글(반박/REBUT_FINAL 포함)을 보냈으면 동의·재반박·종결 셋 중 하나로 반드시 처리하고 resolve까지 끝낸다(§8.3, §8.3.1). 무대응 시 auto-merge 트리거 안 됨


### PR DESCRIPTION
# :pray:Pull Request

## :star:작업내용

- workspace root의 `pr-review-apply` 스킬을 bds 레포에 배포
- `.claude/skills/pr-review-apply/SKILL.md` 추가
- 본인 PR 리뷰 코멘트를 반영/반박/보류로 처리하고 rebase로 원래 커밋을 직접 수정하는 워크플로우 스킬

## :building_construction:사진첨부 (베리 굿):thumbsup:

N/A

## :exclamation:주의 사항

- AGENTS.md 파일들은 스테이징하지 않음

## :package:추가하거나 변경된 패키지

- 없음